### PR TITLE
[Feat] 음성 인식 파이프라인에 공백 포함 음성 추출 기능 구현

### DIFF
--- a/config/model_configs.py
+++ b/config/model_configs.py
@@ -29,7 +29,7 @@ class WhisperXConfig:
     """Configuration for WhisperX speech recognition and alignment"""
 
     # Model settings (matches actual implementation)
-    model_size: str = "base"
+    model_size: str = "large-v3"  # Upgraded for better word alignment
     language: Optional[str] = "en"
     compute_type: str = "float16"
 

--- a/output/friend2_analysis.json
+++ b/output/friend2_analysis.json
@@ -1,0 +1,3333 @@
+{
+  "success": true,
+  "segments": [
+    {
+      "start_time": 0.0,
+      "end_time": 4.28,
+      "duration": 4.28,
+      "speaker_id": "SILENCE",
+      "acoustic_features": {
+        "volume_db": -32.809,
+        "pitch_hz": 195.059,
+        "spectral_centroid": 2118.753,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 195.059,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "[SILENCE]",
+      "words": [
+        {
+          "word": "[SILENCE]",
+          "start_time": 0.0,
+          "end_time": 1.07,
+          "duration": 1.07,
+          "acoustic_features": {
+            "volume_db": -32.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 1.07,
+          "end_time": 2.14,
+          "duration": 1.07,
+          "acoustic_features": {
+            "volume_db": -32.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 2.14,
+          "end_time": 3.21,
+          "duration": 1.0699999999999998,
+          "acoustic_features": {
+            "volume_db": -32.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 3.21,
+          "end_time": 4.28,
+          "duration": 1.0700000000000003,
+          "acoustic_features": {
+            "volume_db": -32.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 4.283,
+      "end_time": 27.352,
+      "duration": 23.069,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -26.686,
+        "pitch_hz": 226.535,
+        "spectral_centroid": 1899.802,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 226.535,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Oh, God. Hey, you want a beer? Oh, no! Open up! Open up! Open up! We'll discuss it in the morning.",
+      "words": [
+        {
+          "word": "Oh,",
+          "start_time": 4.28,
+          "end_time": 5.38,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "God.",
+          "start_time": 5.38,
+          "end_time": 6.48,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Hey,",
+          "start_time": 6.48,
+          "end_time": 7.58,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 7.58,
+          "end_time": 8.68,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "want",
+          "start_time": 8.68,
+          "end_time": 9.78,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 9.78,
+          "end_time": 10.87,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "beer?",
+          "start_time": 10.87,
+          "end_time": 11.97,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh,",
+          "start_time": 11.97,
+          "end_time": 13.07,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no!",
+          "start_time": 13.07,
+          "end_time": 14.17,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Open",
+          "start_time": 14.17,
+          "end_time": 15.27,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "up!",
+          "start_time": 15.27,
+          "end_time": 16.37,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Open",
+          "start_time": 16.37,
+          "end_time": 17.47,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "up!",
+          "start_time": 17.47,
+          "end_time": 18.56,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Open",
+          "start_time": 18.56,
+          "end_time": 19.66,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "up!",
+          "start_time": 19.66,
+          "end_time": 20.76,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We'll",
+          "start_time": 20.76,
+          "end_time": 21.86,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "discuss",
+          "start_time": 21.86,
+          "end_time": 22.96,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 22.96,
+          "end_time": 24.06,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "in",
+          "start_time": 24.06,
+          "end_time": 25.15,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 25.15,
+          "end_time": 26.25,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "morning.",
+          "start_time": 26.25,
+          "end_time": 27.35,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 27.35,
+      "end_time": 35.38,
+      "duration": 8.030000000000001,
+      "speaker_id": "SILENCE",
+      "acoustic_features": {
+        "volume_db": -26.142,
+        "pitch_hz": 210.931,
+        "spectral_centroid": 2079.317,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 210.931,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "[SILENCE]",
+      "words": [
+        {
+          "word": "[SILENCE]",
+          "start_time": 27.35,
+          "end_time": 28.36,
+          "duration": 1.009999999999998,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 28.36,
+          "end_time": 29.36,
+          "duration": 1.0,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 29.36,
+          "end_time": 30.36,
+          "duration": 1.0,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 30.36,
+          "end_time": 31.37,
+          "duration": 1.0100000000000016,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 31.37,
+          "end_time": 32.37,
+          "duration": 0.9999999999999964,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 32.37,
+          "end_time": 33.38,
+          "duration": 1.0100000000000051,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 33.38,
+          "end_time": 34.38,
+          "duration": 1.0,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 34.38,
+          "end_time": 35.38,
+          "duration": 1.0,
+          "acoustic_features": {
+            "volume_db": -26.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 35.384,
+      "end_time": 60.005,
+      "duration": 24.621000000000002,
+      "speaker_id": "SPEAKER_00",
+      "acoustic_features": {
+        "volume_db": -25.063,
+        "pitch_hz": 229.164,
+        "spectral_centroid": 2020.469,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 229.164,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "What the hell is going on? We took our apartment back. I had nothing to do with it. Okay, it was my idea, but I don't feel good about it. Oh! Oh! We are switching back right now.",
+      "words": [
+        {
+          "word": "What",
+          "start_time": 35.38,
+          "end_time": 36.03,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 36.03,
+          "end_time": 36.68,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "hell",
+          "start_time": 36.68,
+          "end_time": 37.33,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is",
+          "start_time": 37.33,
+          "end_time": 37.98,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "going",
+          "start_time": 37.98,
+          "end_time": 38.62,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "on?",
+          "start_time": 38.62,
+          "end_time": 39.27,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 39.27,
+          "end_time": 39.92,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "took",
+          "start_time": 39.92,
+          "end_time": 40.57,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "our",
+          "start_time": 40.57,
+          "end_time": 41.22,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment",
+          "start_time": 41.22,
+          "end_time": 41.86,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back.",
+          "start_time": 41.86,
+          "end_time": 42.51,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 42.51,
+          "end_time": 43.16,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "had",
+          "start_time": 43.16,
+          "end_time": 43.81,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "nothing",
+          "start_time": 43.81,
+          "end_time": 44.45,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 44.45,
+          "end_time": 45.1,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do",
+          "start_time": 45.1,
+          "end_time": 45.75,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "with",
+          "start_time": 45.75,
+          "end_time": 46.4,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 46.4,
+          "end_time": 47.05,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Okay,",
+          "start_time": 47.05,
+          "end_time": 47.69,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 47.69,
+          "end_time": 48.34,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "was",
+          "start_time": 48.34,
+          "end_time": 48.99,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "my",
+          "start_time": 48.99,
+          "end_time": 49.64,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "idea,",
+          "start_time": 49.64,
+          "end_time": 50.29,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "but",
+          "start_time": 50.29,
+          "end_time": 50.93,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 50.93,
+          "end_time": 51.58,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 51.58,
+          "end_time": 52.23,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "feel",
+          "start_time": 52.23,
+          "end_time": 52.88,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "good",
+          "start_time": 52.88,
+          "end_time": 53.53,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "about",
+          "start_time": 53.53,
+          "end_time": 54.17,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 54.17,
+          "end_time": 54.82,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh!",
+          "start_time": 54.82,
+          "end_time": 55.47,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh!",
+          "start_time": 55.47,
+          "end_time": 56.12,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 56.12,
+          "end_time": 56.77,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "are",
+          "start_time": 56.77,
+          "end_time": 57.41,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "switching",
+          "start_time": 57.41,
+          "end_time": 58.06,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back",
+          "start_time": 58.06,
+          "end_time": 58.71,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 58.71,
+          "end_time": 59.36,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "now.",
+          "start_time": 59.36,
+          "end_time": 60.01,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 60.01,
+      "end_time": 60.53,
+      "duration": 0.5200000000000031,
+      "speaker_id": "SILENCE",
+      "acoustic_features": {
+        "volume_db": -60.134,
+        "pitch_hz": 172.399,
+        "spectral_centroid": 2256.16,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 172.399,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "[SILENCE]",
+      "words": [
+        {
+          "word": "[SILENCE]",
+          "start_time": 60.01,
+          "end_time": 60.53,
+          "duration": 0.5200000000000031,
+          "acoustic_features": {
+            "volume_db": -60.1,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 60.528,
+      "end_time": 85.368,
+      "duration": 24.839999999999996,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -26.453,
+        "pitch_hz": 284.535,
+        "spectral_centroid": 2182.904,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 284.535,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "No, we're not. We're not leaving. Well, you're going to have to leave sometime because you both have jobs. And as soon as you do, we're switching it back. There's nothing you can do to stop us. Right, Joe? I don't know. What? I don't want to move again. I don't care. This is our apartment. And they stole it. You stole.",
+      "words": [
+        {
+          "word": "No,",
+          "start_time": 60.53,
+          "end_time": 60.93,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we're",
+          "start_time": 60.93,
+          "end_time": 61.33,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not.",
+          "start_time": 61.33,
+          "end_time": 61.73,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We're",
+          "start_time": 61.73,
+          "end_time": 62.13,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 62.13,
+          "end_time": 62.53,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "leaving.",
+          "start_time": 62.53,
+          "end_time": 62.93,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Well,",
+          "start_time": 62.93,
+          "end_time": 63.33,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you're",
+          "start_time": 63.33,
+          "end_time": 63.73,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "going",
+          "start_time": 63.73,
+          "end_time": 64.13,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 64.13,
+          "end_time": 64.53,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 64.53,
+          "end_time": 64.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 64.94,
+          "end_time": 65.34,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "leave",
+          "start_time": 65.34,
+          "end_time": 65.74,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "sometime",
+          "start_time": 65.74,
+          "end_time": 66.14,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "because",
+          "start_time": 66.14,
+          "end_time": 66.54,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 66.54,
+          "end_time": 66.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "both",
+          "start_time": 66.94,
+          "end_time": 67.34,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 67.34,
+          "end_time": 67.74,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "jobs.",
+          "start_time": 67.74,
+          "end_time": 68.14,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 68.14,
+          "end_time": 68.54,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 68.54,
+          "end_time": 68.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "soon",
+          "start_time": 68.94,
+          "end_time": 69.34,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 69.34,
+          "end_time": 69.74,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 69.74,
+          "end_time": 70.14,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do,",
+          "start_time": 70.14,
+          "end_time": 70.54,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we're",
+          "start_time": 70.54,
+          "end_time": 70.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "switching",
+          "start_time": 70.94,
+          "end_time": 71.35,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 71.35,
+          "end_time": 71.75,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back.",
+          "start_time": 71.75,
+          "end_time": 72.15,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "There's",
+          "start_time": 72.15,
+          "end_time": 72.55,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "nothing",
+          "start_time": 72.55,
+          "end_time": 72.95,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 72.95,
+          "end_time": 73.35,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can",
+          "start_time": 73.35,
+          "end_time": 73.75,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do",
+          "start_time": 73.75,
+          "end_time": 74.15,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 74.15,
+          "end_time": 74.55,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stop",
+          "start_time": 74.55,
+          "end_time": 74.95,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us.",
+          "start_time": 74.95,
+          "end_time": 75.35,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Right,",
+          "start_time": 75.35,
+          "end_time": 75.75,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Joe?",
+          "start_time": 75.75,
+          "end_time": 76.15,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 76.15,
+          "end_time": 76.55,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 76.55,
+          "end_time": 76.95,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know.",
+          "start_time": 76.95,
+          "end_time": 77.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "What?",
+          "start_time": 77.36,
+          "end_time": 77.76,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 77.76,
+          "end_time": 78.16,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 78.16,
+          "end_time": 78.56,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "want",
+          "start_time": 78.56,
+          "end_time": 78.96,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 78.96,
+          "end_time": 79.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "move",
+          "start_time": 79.36,
+          "end_time": 79.76,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "again.",
+          "start_time": 79.76,
+          "end_time": 80.16,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 80.16,
+          "end_time": 80.56,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 80.56,
+          "end_time": 80.96,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "care.",
+          "start_time": 80.96,
+          "end_time": 81.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "This",
+          "start_time": 81.36,
+          "end_time": 81.76,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is",
+          "start_time": 81.76,
+          "end_time": 82.16,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "our",
+          "start_time": 82.16,
+          "end_time": 82.56,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment.",
+          "start_time": 82.56,
+          "end_time": 82.96,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 82.96,
+          "end_time": 83.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "they",
+          "start_time": 83.36,
+          "end_time": 83.77,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stole",
+          "start_time": 83.77,
+          "end_time": 84.17,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 84.17,
+          "end_time": 84.57,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "You",
+          "start_time": 84.57,
+          "end_time": 84.97,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stole.",
+          "start_time": 84.97,
+          "end_time": 85.37,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 85.37,
+      "end_time": 86.65,
+      "duration": 1.2800000000000011,
+      "speaker_id": "SILENCE",
+      "acoustic_features": {
+        "volume_db": -28.906,
+        "pitch_hz": 226.861,
+        "spectral_centroid": 1783.666,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 226.861,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "[SILENCE]",
+      "words": [
+        {
+          "word": "[SILENCE]",
+          "start_time": 85.37,
+          "end_time": 86.65,
+          "duration": 1.2800000000000011,
+          "acoustic_features": {
+            "volume_db": -28.9,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 86.65,
+      "end_time": 115.304,
+      "duration": 28.653999999999996,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -27.45,
+        "pitch_hz": 218.095,
+        "spectral_centroid": 2371.157,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 218.095,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Our apartment. We won that apartment fair and square twice, and I'm getting it back right now. I'm getting it back right now! All right. We figured you might respond this way, so we have a backup offer. Oh, no, no, no. No more offers. You can't offer anything to us. Let us keep the apartment, and as a thank you... Rachel and I will kiss for one minute.",
+      "words": [
+        {
+          "word": "Our",
+          "start_time": 86.65,
+          "end_time": 87.07,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment.",
+          "start_time": 87.07,
+          "end_time": 87.48,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 87.48,
+          "end_time": 87.9,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "won",
+          "start_time": 87.9,
+          "end_time": 88.31,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 88.31,
+          "end_time": 88.73,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment",
+          "start_time": 88.73,
+          "end_time": 89.14,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "fair",
+          "start_time": 89.14,
+          "end_time": 89.56,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 89.56,
+          "end_time": 89.97,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "square",
+          "start_time": 89.97,
+          "end_time": 90.39,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "twice,",
+          "start_time": 90.39,
+          "end_time": 90.8,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 90.8,
+          "end_time": 91.22,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I'm",
+          "start_time": 91.22,
+          "end_time": 91.63,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "getting",
+          "start_time": 91.63,
+          "end_time": 92.05,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 92.05,
+          "end_time": 92.46,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back",
+          "start_time": 92.46,
+          "end_time": 92.88,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 92.88,
+          "end_time": 93.29,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "now.",
+          "start_time": 93.29,
+          "end_time": 93.71,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I'm",
+          "start_time": 93.71,
+          "end_time": 94.12,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "getting",
+          "start_time": 94.12,
+          "end_time": 94.54,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 94.54,
+          "end_time": 94.96,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back",
+          "start_time": 94.96,
+          "end_time": 95.37,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 95.37,
+          "end_time": 95.79,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "now!",
+          "start_time": 95.79,
+          "end_time": 96.2,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "All",
+          "start_time": 96.2,
+          "end_time": 96.62,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right.",
+          "start_time": 96.62,
+          "end_time": 97.03,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 97.03,
+          "end_time": 97.45,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "figured",
+          "start_time": 97.45,
+          "end_time": 97.86,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 97.86,
+          "end_time": 98.28,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "might",
+          "start_time": 98.28,
+          "end_time": 98.69,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "respond",
+          "start_time": 98.69,
+          "end_time": 99.11,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "this",
+          "start_time": 99.11,
+          "end_time": 99.52,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "way,",
+          "start_time": 99.52,
+          "end_time": 99.94,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "so",
+          "start_time": 99.94,
+          "end_time": 100.35,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we",
+          "start_time": 100.35,
+          "end_time": 100.77,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 100.77,
+          "end_time": 101.18,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 101.18,
+          "end_time": 101.6,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "backup",
+          "start_time": 101.6,
+          "end_time": 102.02,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "offer.",
+          "start_time": 102.02,
+          "end_time": 102.43,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh,",
+          "start_time": 102.43,
+          "end_time": 102.85,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no,",
+          "start_time": 102.85,
+          "end_time": 103.26,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no,",
+          "start_time": 103.26,
+          "end_time": 103.68,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no.",
+          "start_time": 103.68,
+          "end_time": 104.09,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "No",
+          "start_time": 104.09,
+          "end_time": 104.51,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "more",
+          "start_time": 104.51,
+          "end_time": 104.92,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "offers.",
+          "start_time": 104.92,
+          "end_time": 105.34,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "You",
+          "start_time": 105.34,
+          "end_time": 105.75,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can't",
+          "start_time": 105.75,
+          "end_time": 106.17,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "offer",
+          "start_time": 106.17,
+          "end_time": 106.58,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "anything",
+          "start_time": 106.58,
+          "end_time": 107.0,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 107.0,
+          "end_time": 107.41,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us.",
+          "start_time": 107.41,
+          "end_time": 107.83,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Let",
+          "start_time": 107.83,
+          "end_time": 108.24,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us",
+          "start_time": 108.24,
+          "end_time": 108.66,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "keep",
+          "start_time": 108.66,
+          "end_time": 109.07,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 109.07,
+          "end_time": 109.49,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment,",
+          "start_time": 109.49,
+          "end_time": 109.91,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 109.91,
+          "end_time": 110.32,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 110.32,
+          "end_time": 110.74,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 110.74,
+          "end_time": 111.15,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "thank",
+          "start_time": 111.15,
+          "end_time": 111.57,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you...",
+          "start_time": 111.57,
+          "end_time": 111.98,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Rachel",
+          "start_time": 111.98,
+          "end_time": 112.4,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 112.4,
+          "end_time": 112.81,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 112.81,
+          "end_time": 113.23,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "will",
+          "start_time": 113.23,
+          "end_time": 113.64,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "kiss",
+          "start_time": 113.64,
+          "end_time": 114.06,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 114.06,
+          "end_time": 114.47,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 114.47,
+          "end_time": 114.89,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "minute.",
+          "start_time": 114.89,
+          "end_time": 115.3,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 115.3,
+      "end_time": 119.88,
+      "duration": 4.579999999999998,
+      "speaker_id": "SILENCE",
+      "acoustic_features": {
+        "volume_db": -28.823,
+        "pitch_hz": 221.176,
+        "spectral_centroid": 2166.373,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 221.176,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "[SILENCE]",
+      "words": [
+        {
+          "word": "[SILENCE]",
+          "start_time": 115.3,
+          "end_time": 116.45,
+          "duration": 1.1500000000000057,
+          "acoustic_features": {
+            "volume_db": -28.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 116.45,
+          "end_time": 117.59,
+          "duration": 1.1400000000000006,
+          "acoustic_features": {
+            "volume_db": -28.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 117.59,
+          "end_time": 118.73,
+          "duration": 1.1400000000000006,
+          "acoustic_features": {
+            "volume_db": -28.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 118.73,
+          "end_time": 119.88,
+          "duration": 1.1499999999999915,
+          "acoustic_features": {
+            "volume_db": -28.8,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 119.877,
+      "end_time": 148.784,
+      "duration": 28.906999999999996,
+      "speaker_id": "SPEAKER_00",
+      "acoustic_features": {
+        "volume_db": -26.363,
+        "pitch_hz": 305.054,
+        "spectral_centroid": 2099.946,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 305.054,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Totally worth it. It was one good minute. Good night. Good night. Men are such idiots. I know. Can you believe something that stupid actually got us our apartment back? It's so funny to think, if you had just done that right after the last contest, no one would have had to move at all. Let's pretend that's not true. Yeah.",
+      "words": [
+        {
+          "word": "Totally",
+          "start_time": 119.88,
+          "end_time": 120.35,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "worth",
+          "start_time": 120.35,
+          "end_time": 120.82,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 120.82,
+          "end_time": 121.3,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "It",
+          "start_time": 121.3,
+          "end_time": 121.77,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "was",
+          "start_time": 121.77,
+          "end_time": 122.25,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 122.25,
+          "end_time": 122.72,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "good",
+          "start_time": 122.72,
+          "end_time": 123.19,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "minute.",
+          "start_time": 123.19,
+          "end_time": 123.67,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Good",
+          "start_time": 123.67,
+          "end_time": 124.14,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "night.",
+          "start_time": 124.14,
+          "end_time": 124.62,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Good",
+          "start_time": 124.62,
+          "end_time": 125.09,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "night.",
+          "start_time": 125.09,
+          "end_time": 125.56,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Men",
+          "start_time": 125.56,
+          "end_time": 126.04,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "are",
+          "start_time": 126.04,
+          "end_time": 126.51,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "such",
+          "start_time": 126.51,
+          "end_time": 126.99,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "idiots.",
+          "start_time": 126.99,
+          "end_time": 127.46,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 127.46,
+          "end_time": 127.93,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know.",
+          "start_time": 127.93,
+          "end_time": 128.41,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Can",
+          "start_time": 128.41,
+          "end_time": 128.88,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 128.88,
+          "end_time": 129.35,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "believe",
+          "start_time": 129.35,
+          "end_time": 129.83,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "something",
+          "start_time": 129.83,
+          "end_time": 130.3,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 130.3,
+          "end_time": 130.78,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stupid",
+          "start_time": 130.78,
+          "end_time": 131.25,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "actually",
+          "start_time": 131.25,
+          "end_time": 131.72,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "got",
+          "start_time": 131.72,
+          "end_time": 132.2,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us",
+          "start_time": 132.2,
+          "end_time": 132.67,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "our",
+          "start_time": 132.67,
+          "end_time": 133.15,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment",
+          "start_time": 133.15,
+          "end_time": 133.62,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back?",
+          "start_time": 133.62,
+          "end_time": 134.09,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "It's",
+          "start_time": 134.09,
+          "end_time": 134.57,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "so",
+          "start_time": 134.57,
+          "end_time": 135.04,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "funny",
+          "start_time": 135.04,
+          "end_time": 135.52,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 135.52,
+          "end_time": 135.99,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "think,",
+          "start_time": 135.99,
+          "end_time": 136.46,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "if",
+          "start_time": 136.46,
+          "end_time": 136.94,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 136.94,
+          "end_time": 137.41,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "had",
+          "start_time": 137.41,
+          "end_time": 137.88,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "just",
+          "start_time": 137.88,
+          "end_time": 138.36,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "done",
+          "start_time": 138.36,
+          "end_time": 138.83,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 138.83,
+          "end_time": 139.31,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 139.31,
+          "end_time": 139.78,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "after",
+          "start_time": 139.78,
+          "end_time": 140.25,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 140.25,
+          "end_time": 140.73,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "last",
+          "start_time": 140.73,
+          "end_time": 141.2,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "contest,",
+          "start_time": 141.2,
+          "end_time": 141.68,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no",
+          "start_time": 141.68,
+          "end_time": 142.15,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 142.15,
+          "end_time": 142.62,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "would",
+          "start_time": 142.62,
+          "end_time": 143.1,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 143.1,
+          "end_time": 143.57,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "had",
+          "start_time": 143.57,
+          "end_time": 144.05,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 144.05,
+          "end_time": 144.52,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "move",
+          "start_time": 144.52,
+          "end_time": 144.99,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "at",
+          "start_time": 144.99,
+          "end_time": 145.47,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "all.",
+          "start_time": 145.47,
+          "end_time": 145.94,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Let's",
+          "start_time": 145.94,
+          "end_time": 146.41,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "pretend",
+          "start_time": 146.41,
+          "end_time": 146.89,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that's",
+          "start_time": 146.89,
+          "end_time": 147.36,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 147.36,
+          "end_time": 147.84,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "true.",
+          "start_time": 147.84,
+          "end_time": 148.31,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Yeah.",
+          "start_time": 148.31,
+          "end_time": 148.78,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 148.78,
+      "end_time": 158.55,
+      "duration": 9.77000000000001,
+      "speaker_id": "SILENCE",
+      "acoustic_features": {
+        "volume_db": -29.669,
+        "pitch_hz": 219.326,
+        "spectral_centroid": 1047.705,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 219.326,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "[SILENCE]",
+      "words": [
+        {
+          "word": "[SILENCE]",
+          "start_time": 148.78,
+          "end_time": 149.87,
+          "duration": 1.0900000000000034,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 149.87,
+          "end_time": 150.95,
+          "duration": 1.079999999999984,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 150.95,
+          "end_time": 152.04,
+          "duration": 1.0900000000000034,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 152.04,
+          "end_time": 153.12,
+          "duration": 1.0800000000000125,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 153.12,
+          "end_time": 154.21,
+          "duration": 1.0900000000000034,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 154.21,
+          "end_time": 155.29,
+          "duration": 1.079999999999984,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 155.29,
+          "end_time": 156.38,
+          "duration": 1.0900000000000034,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 156.38,
+          "end_time": 157.46,
+          "duration": 1.0800000000000125,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "[SILENCE]",
+          "start_time": 157.46,
+          "end_time": 158.55,
+          "duration": 1.0900000000000034,
+          "acoustic_features": {
+            "volume_db": -29.7,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    }
+  ],
+  "speakers": {
+    "SILENCE": {
+      "total_duration": 28.460000000000015,
+      "segment_count": 6
+    },
+    "SPEAKER_01": {
+      "total_duration": 76.56299999999999,
+      "segment_count": 3
+    },
+    "SPEAKER_00": {
+      "total_duration": 53.528,
+      "segment_count": 2
+    }
+  },
+  "metadata": {
+    "filename": "friend2.mp4",
+    "duration": 158.5,
+    "total_segments": 11,
+    "unique_speakers": 3,
+    "processing_time": 259.990478,
+    "language_requested": "en",
+    "language_detected": "en",
+    "processing_mode": "targeted",
+    "processed_at": "2025-09-17T22:38:01.913843"
+  },
+  "processing_time": 259.990478,
+  "error": null,
+  "error_code": null
+}

--- a/output/friends2_analysis_Copy.json
+++ b/output/friends2_analysis_Copy.json
@@ -1,0 +1,2900 @@
+{
+  "success": true,
+  "segments": [
+    {
+      "start_time": 4.283,
+      "end_time": 27.352,
+      "duration": 23.069,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -26.686,
+        "pitch_hz": 226.535,
+        "spectral_centroid": 1899.802,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 226.535,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Oh, God. Hey, you want a beer? Oh, no! Open up! Open up! Open up! We'll discuss it in the morning.",
+      "words": [
+        {
+          "word": "Oh,",
+          "start_time": 4.28,
+          "end_time": 5.38,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "God.",
+          "start_time": 5.38,
+          "end_time": 6.48,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Hey,",
+          "start_time": 6.48,
+          "end_time": 7.58,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 7.58,
+          "end_time": 8.68,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "want",
+          "start_time": 8.68,
+          "end_time": 9.78,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 9.78,
+          "end_time": 10.87,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "beer?",
+          "start_time": 10.87,
+          "end_time": 11.97,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh,",
+          "start_time": 11.97,
+          "end_time": 13.07,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no!",
+          "start_time": 13.07,
+          "end_time": 14.17,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Open",
+          "start_time": 14.17,
+          "end_time": 15.27,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "up!",
+          "start_time": 15.27,
+          "end_time": 16.37,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Open",
+          "start_time": 16.37,
+          "end_time": 17.47,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "up!",
+          "start_time": 17.47,
+          "end_time": 18.56,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Open",
+          "start_time": 18.56,
+          "end_time": 19.66,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "up!",
+          "start_time": 19.66,
+          "end_time": 20.76,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We'll",
+          "start_time": 20.76,
+          "end_time": 21.86,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "discuss",
+          "start_time": 21.86,
+          "end_time": 22.96,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 22.96,
+          "end_time": 24.06,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "in",
+          "start_time": 24.06,
+          "end_time": 25.15,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 25.15,
+          "end_time": 26.25,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "morning.",
+          "start_time": 26.25,
+          "end_time": 27.35,
+          "duration": 1.1,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 35.384,
+      "end_time": 60.005,
+      "duration": 24.621000000000002,
+      "speaker_id": "SPEAKER_00",
+      "acoustic_features": {
+        "volume_db": -25.063,
+        "pitch_hz": 229.164,
+        "spectral_centroid": 2020.469,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 229.164,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "What the hell is going on? We took our apartment back. I had nothing to do with it. Okay, it was my idea, but I don't feel good about it. Oh! Oh! We are switching back right now.",
+      "words": [
+        {
+          "word": "What",
+          "start_time": 35.38,
+          "end_time": 36.03,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 36.03,
+          "end_time": 36.68,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "hell",
+          "start_time": 36.68,
+          "end_time": 37.33,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is",
+          "start_time": 37.33,
+          "end_time": 37.98,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "going",
+          "start_time": 37.98,
+          "end_time": 38.62,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "on?",
+          "start_time": 38.62,
+          "end_time": 39.27,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 39.27,
+          "end_time": 39.92,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "took",
+          "start_time": 39.92,
+          "end_time": 40.57,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "our",
+          "start_time": 40.57,
+          "end_time": 41.22,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment",
+          "start_time": 41.22,
+          "end_time": 41.86,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back.",
+          "start_time": 41.86,
+          "end_time": 42.51,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 42.51,
+          "end_time": 43.16,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "had",
+          "start_time": 43.16,
+          "end_time": 43.81,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "nothing",
+          "start_time": 43.81,
+          "end_time": 44.45,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 44.45,
+          "end_time": 45.1,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do",
+          "start_time": 45.1,
+          "end_time": 45.75,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "with",
+          "start_time": 45.75,
+          "end_time": 46.4,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 46.4,
+          "end_time": 47.05,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Okay,",
+          "start_time": 47.05,
+          "end_time": 47.69,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 47.69,
+          "end_time": 48.34,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "was",
+          "start_time": 48.34,
+          "end_time": 48.99,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "my",
+          "start_time": 48.99,
+          "end_time": 49.64,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "idea,",
+          "start_time": 49.64,
+          "end_time": 50.29,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "but",
+          "start_time": 50.29,
+          "end_time": 50.93,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 50.93,
+          "end_time": 51.58,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 51.58,
+          "end_time": 52.23,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "feel",
+          "start_time": 52.23,
+          "end_time": 52.88,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "good",
+          "start_time": 52.88,
+          "end_time": 53.53,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "about",
+          "start_time": 53.53,
+          "end_time": 54.17,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 54.17,
+          "end_time": 54.82,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh!",
+          "start_time": 54.82,
+          "end_time": 55.47,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh!",
+          "start_time": 55.47,
+          "end_time": 56.12,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 56.12,
+          "end_time": 56.77,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "are",
+          "start_time": 56.77,
+          "end_time": 57.41,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "switching",
+          "start_time": 57.41,
+          "end_time": 58.06,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back",
+          "start_time": 58.06,
+          "end_time": 58.71,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 58.71,
+          "end_time": 59.36,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "now.",
+          "start_time": 59.36,
+          "end_time": 60.01,
+          "duration": 0.65,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 60.528,
+      "end_time": 85.368,
+      "duration": 24.839999999999996,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -26.453,
+        "pitch_hz": 284.535,
+        "spectral_centroid": 2182.904,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 284.535,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "No, we're not. We're not leaving. Well, you're going to have to leave sometime because you both have jobs. And as soon as you do, we're switching it back. There's nothing you can do to stop us. Right, Joe? I don't know. What? I don't want to move again. I don't care. This is our apartment. And they stole it. You stole.",
+      "words": [
+        {
+          "word": "No,",
+          "start_time": 60.53,
+          "end_time": 60.93,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we're",
+          "start_time": 60.93,
+          "end_time": 61.33,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not.",
+          "start_time": 61.33,
+          "end_time": 61.73,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We're",
+          "start_time": 61.73,
+          "end_time": 62.13,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 62.13,
+          "end_time": 62.53,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "leaving.",
+          "start_time": 62.53,
+          "end_time": 62.93,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Well,",
+          "start_time": 62.93,
+          "end_time": 63.33,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you're",
+          "start_time": 63.33,
+          "end_time": 63.73,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "going",
+          "start_time": 63.73,
+          "end_time": 64.13,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 64.13,
+          "end_time": 64.53,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 64.53,
+          "end_time": 64.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 64.94,
+          "end_time": 65.34,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "leave",
+          "start_time": 65.34,
+          "end_time": 65.74,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "sometime",
+          "start_time": 65.74,
+          "end_time": 66.14,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "because",
+          "start_time": 66.14,
+          "end_time": 66.54,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 66.54,
+          "end_time": 66.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "both",
+          "start_time": 66.94,
+          "end_time": 67.34,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 67.34,
+          "end_time": 67.74,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "jobs.",
+          "start_time": 67.74,
+          "end_time": 68.14,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 68.14,
+          "end_time": 68.54,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 68.54,
+          "end_time": 68.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "soon",
+          "start_time": 68.94,
+          "end_time": 69.34,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 69.34,
+          "end_time": 69.74,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 69.74,
+          "end_time": 70.14,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do,",
+          "start_time": 70.14,
+          "end_time": 70.54,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we're",
+          "start_time": 70.54,
+          "end_time": 70.94,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "switching",
+          "start_time": 70.94,
+          "end_time": 71.35,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 71.35,
+          "end_time": 71.75,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back.",
+          "start_time": 71.75,
+          "end_time": 72.15,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "There's",
+          "start_time": 72.15,
+          "end_time": 72.55,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "nothing",
+          "start_time": 72.55,
+          "end_time": 72.95,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 72.95,
+          "end_time": 73.35,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can",
+          "start_time": 73.35,
+          "end_time": 73.75,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do",
+          "start_time": 73.75,
+          "end_time": 74.15,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 74.15,
+          "end_time": 74.55,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stop",
+          "start_time": 74.55,
+          "end_time": 74.95,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us.",
+          "start_time": 74.95,
+          "end_time": 75.35,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Right,",
+          "start_time": 75.35,
+          "end_time": 75.75,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Joe?",
+          "start_time": 75.75,
+          "end_time": 76.15,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 76.15,
+          "end_time": 76.55,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 76.55,
+          "end_time": 76.95,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know.",
+          "start_time": 76.95,
+          "end_time": 77.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "What?",
+          "start_time": 77.36,
+          "end_time": 77.76,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 77.76,
+          "end_time": 78.16,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 78.16,
+          "end_time": 78.56,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "want",
+          "start_time": 78.56,
+          "end_time": 78.96,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 78.96,
+          "end_time": 79.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "move",
+          "start_time": 79.36,
+          "end_time": 79.76,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "again.",
+          "start_time": 79.76,
+          "end_time": 80.16,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 80.16,
+          "end_time": 80.56,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 80.56,
+          "end_time": 80.96,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "care.",
+          "start_time": 80.96,
+          "end_time": 81.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "This",
+          "start_time": 81.36,
+          "end_time": 81.76,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is",
+          "start_time": 81.76,
+          "end_time": 82.16,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "our",
+          "start_time": 82.16,
+          "end_time": 82.56,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment.",
+          "start_time": 82.56,
+          "end_time": 82.96,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 82.96,
+          "end_time": 83.36,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "they",
+          "start_time": 83.36,
+          "end_time": 83.77,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stole",
+          "start_time": 83.77,
+          "end_time": 84.17,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 84.17,
+          "end_time": 84.57,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "You",
+          "start_time": 84.57,
+          "end_time": 84.97,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stole.",
+          "start_time": 84.97,
+          "end_time": 85.37,
+          "duration": 0.4,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 86.65,
+      "end_time": 115.304,
+      "duration": 28.653999999999996,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -27.45,
+        "pitch_hz": 218.095,
+        "spectral_centroid": 2371.157,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 218.095,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Our apartment. We won that apartment fair and square twice, and I'm getting it back right now. I'm getting it back right now! All right. We figured you might respond this way, so we have a backup offer. Oh, no, no, no. No more offers. You can't offer anything to us. Let us keep the apartment, and as a thank you... Rachel and I will kiss for one minute.",
+      "words": [
+        {
+          "word": "Our",
+          "start_time": 86.65,
+          "end_time": 87.07,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment.",
+          "start_time": 87.07,
+          "end_time": 87.48,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 87.48,
+          "end_time": 87.9,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "won",
+          "start_time": 87.9,
+          "end_time": 88.31,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 88.31,
+          "end_time": 88.73,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment",
+          "start_time": 88.73,
+          "end_time": 89.14,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "fair",
+          "start_time": 89.14,
+          "end_time": 89.56,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 89.56,
+          "end_time": 89.97,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "square",
+          "start_time": 89.97,
+          "end_time": 90.39,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "twice,",
+          "start_time": 90.39,
+          "end_time": 90.8,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 90.8,
+          "end_time": 91.22,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I'm",
+          "start_time": 91.22,
+          "end_time": 91.63,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "getting",
+          "start_time": 91.63,
+          "end_time": 92.05,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 92.05,
+          "end_time": 92.46,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back",
+          "start_time": 92.46,
+          "end_time": 92.88,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 92.88,
+          "end_time": 93.29,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "now.",
+          "start_time": 93.29,
+          "end_time": 93.71,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I'm",
+          "start_time": 93.71,
+          "end_time": 94.12,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "getting",
+          "start_time": 94.12,
+          "end_time": 94.54,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 94.54,
+          "end_time": 94.96,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back",
+          "start_time": 94.96,
+          "end_time": 95.37,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 95.37,
+          "end_time": 95.79,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "now!",
+          "start_time": 95.79,
+          "end_time": 96.2,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "All",
+          "start_time": 96.2,
+          "end_time": 96.62,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right.",
+          "start_time": 96.62,
+          "end_time": 97.03,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "We",
+          "start_time": 97.03,
+          "end_time": 97.45,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "figured",
+          "start_time": 97.45,
+          "end_time": 97.86,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 97.86,
+          "end_time": 98.28,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "might",
+          "start_time": 98.28,
+          "end_time": 98.69,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "respond",
+          "start_time": 98.69,
+          "end_time": 99.11,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "this",
+          "start_time": 99.11,
+          "end_time": 99.52,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "way,",
+          "start_time": 99.52,
+          "end_time": 99.94,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "so",
+          "start_time": 99.94,
+          "end_time": 100.35,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we",
+          "start_time": 100.35,
+          "end_time": 100.77,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 100.77,
+          "end_time": 101.18,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 101.18,
+          "end_time": 101.6,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "backup",
+          "start_time": 101.6,
+          "end_time": 102.02,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "offer.",
+          "start_time": 102.02,
+          "end_time": 102.43,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh,",
+          "start_time": 102.43,
+          "end_time": 102.85,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no,",
+          "start_time": 102.85,
+          "end_time": 103.26,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no,",
+          "start_time": 103.26,
+          "end_time": 103.68,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no.",
+          "start_time": 103.68,
+          "end_time": 104.09,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "No",
+          "start_time": 104.09,
+          "end_time": 104.51,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "more",
+          "start_time": 104.51,
+          "end_time": 104.92,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "offers.",
+          "start_time": 104.92,
+          "end_time": 105.34,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "You",
+          "start_time": 105.34,
+          "end_time": 105.75,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can't",
+          "start_time": 105.75,
+          "end_time": 106.17,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "offer",
+          "start_time": 106.17,
+          "end_time": 106.58,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "anything",
+          "start_time": 106.58,
+          "end_time": 107.0,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 107.0,
+          "end_time": 107.41,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us.",
+          "start_time": 107.41,
+          "end_time": 107.83,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Let",
+          "start_time": 107.83,
+          "end_time": 108.24,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us",
+          "start_time": 108.24,
+          "end_time": 108.66,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "keep",
+          "start_time": 108.66,
+          "end_time": 109.07,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 109.07,
+          "end_time": 109.49,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment,",
+          "start_time": 109.49,
+          "end_time": 109.91,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 109.91,
+          "end_time": 110.32,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 110.32,
+          "end_time": 110.74,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 110.74,
+          "end_time": 111.15,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "thank",
+          "start_time": 111.15,
+          "end_time": 111.57,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you...",
+          "start_time": 111.57,
+          "end_time": 111.98,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Rachel",
+          "start_time": 111.98,
+          "end_time": 112.4,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 112.4,
+          "end_time": 112.81,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 112.81,
+          "end_time": 113.23,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "will",
+          "start_time": 113.23,
+          "end_time": 113.64,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "kiss",
+          "start_time": 113.64,
+          "end_time": 114.06,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 114.06,
+          "end_time": 114.47,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 114.47,
+          "end_time": 114.89,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "minute.",
+          "start_time": 114.89,
+          "end_time": 115.3,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 119.877,
+      "end_time": 148.784,
+      "duration": 28.906999999999996,
+      "speaker_id": "SPEAKER_00",
+      "acoustic_features": {
+        "volume_db": -26.363,
+        "pitch_hz": 305.054,
+        "spectral_centroid": 2099.946,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 305.054,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Totally worth it. It was one good minute. Good night. Good night. Men are such idiots. I know. Can you believe something that stupid actually got us our apartment back? It's so funny to think, if you had just done that right after the last contest, no one would have had to move at all. Let's pretend that's not true. Yeah.",
+      "words": [
+        {
+          "word": "Totally",
+          "start_time": 119.88,
+          "end_time": 120.35,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "worth",
+          "start_time": 120.35,
+          "end_time": 120.82,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 120.82,
+          "end_time": 121.3,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "It",
+          "start_time": 121.3,
+          "end_time": 121.77,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "was",
+          "start_time": 121.77,
+          "end_time": 122.25,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 122.25,
+          "end_time": 122.72,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "good",
+          "start_time": 122.72,
+          "end_time": 123.19,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "minute.",
+          "start_time": 123.19,
+          "end_time": 123.67,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Good",
+          "start_time": 123.67,
+          "end_time": 124.14,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "night.",
+          "start_time": 124.14,
+          "end_time": 124.62,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Good",
+          "start_time": 124.62,
+          "end_time": 125.09,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "night.",
+          "start_time": 125.09,
+          "end_time": 125.56,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Men",
+          "start_time": 125.56,
+          "end_time": 126.04,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "are",
+          "start_time": 126.04,
+          "end_time": 126.51,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "such",
+          "start_time": 126.51,
+          "end_time": 126.99,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "idiots.",
+          "start_time": 126.99,
+          "end_time": 127.46,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 127.46,
+          "end_time": 127.93,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know.",
+          "start_time": 127.93,
+          "end_time": 128.41,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Can",
+          "start_time": 128.41,
+          "end_time": 128.88,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 128.88,
+          "end_time": 129.35,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "believe",
+          "start_time": 129.35,
+          "end_time": 129.83,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "something",
+          "start_time": 129.83,
+          "end_time": 130.3,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 130.3,
+          "end_time": 130.78,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "stupid",
+          "start_time": 130.78,
+          "end_time": 131.25,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "actually",
+          "start_time": 131.25,
+          "end_time": 131.72,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "got",
+          "start_time": 131.72,
+          "end_time": 132.2,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "us",
+          "start_time": 132.2,
+          "end_time": 132.67,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "our",
+          "start_time": 132.67,
+          "end_time": 133.15,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "apartment",
+          "start_time": 133.15,
+          "end_time": 133.62,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "back?",
+          "start_time": 133.62,
+          "end_time": 134.09,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "It's",
+          "start_time": 134.09,
+          "end_time": 134.57,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "so",
+          "start_time": 134.57,
+          "end_time": 135.04,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "funny",
+          "start_time": 135.04,
+          "end_time": 135.52,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 135.52,
+          "end_time": 135.99,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "think,",
+          "start_time": 135.99,
+          "end_time": 136.46,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "if",
+          "start_time": 136.46,
+          "end_time": 136.94,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 136.94,
+          "end_time": 137.41,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "had",
+          "start_time": 137.41,
+          "end_time": 137.88,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "just",
+          "start_time": 137.88,
+          "end_time": 138.36,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "done",
+          "start_time": 138.36,
+          "end_time": 138.83,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 138.83,
+          "end_time": 139.31,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right",
+          "start_time": 139.31,
+          "end_time": 139.78,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "after",
+          "start_time": 139.78,
+          "end_time": 140.25,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 140.25,
+          "end_time": 140.73,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "last",
+          "start_time": 140.73,
+          "end_time": 141.2,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "contest,",
+          "start_time": 141.2,
+          "end_time": 141.68,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "no",
+          "start_time": 141.68,
+          "end_time": 142.15,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 142.15,
+          "end_time": 142.62,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "would",
+          "start_time": 142.62,
+          "end_time": 143.1,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 143.1,
+          "end_time": 143.57,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "had",
+          "start_time": 143.57,
+          "end_time": 144.05,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 144.05,
+          "end_time": 144.52,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "move",
+          "start_time": 144.52,
+          "end_time": 144.99,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "at",
+          "start_time": 144.99,
+          "end_time": 145.47,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "all.",
+          "start_time": 145.47,
+          "end_time": 145.94,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Let's",
+          "start_time": 145.94,
+          "end_time": 146.41,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "pretend",
+          "start_time": 146.41,
+          "end_time": 146.89,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that's",
+          "start_time": 146.89,
+          "end_time": 147.36,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 147.36,
+          "end_time": 147.84,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "true.",
+          "start_time": 147.84,
+          "end_time": 148.31,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Yeah.",
+          "start_time": 148.31,
+          "end_time": 148.78,
+          "duration": 0.47,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    }
+  ],
+  "speakers": {
+    "SPEAKER_01": {
+      "total_duration": 76.56299999999999,
+      "segment_count": 3
+    },
+    "SPEAKER_00": {
+      "total_duration": 53.528,
+      "segment_count": 2
+    }
+  },
+  "metadata": {
+    "filename": "friend2.mp4",
+    "duration": 158.5,
+    "total_segments": 5,
+    "unique_speakers": 2,
+    "processing_time": 271.533275,
+    "language_requested": "en",
+    "language_detected": "en",
+    "processing_mode": "targeted",
+    "processed_at": "2025-09-17T22:28:01.129036"
+  },
+  "processing_time": 271.533275,
+  "error": null,
+  "error_code": null
+}

--- a/output/friends_analysis.json
+++ b/output/friends_analysis.json
@@ -1,0 +1,2958 @@
+{
+  "success": true,
+  "metadata": {
+    "filename": "friends.mp4",
+    "duration": 143.4,
+    "total_segments": 6,
+    "unique_speakers": 4,
+    "sample_rate": 16000,
+    "processed_at": "2025-09-17T22:16:15.632190",
+    "processing_time": 322.992038,
+    "processing_mode": "real_ml_models",
+    "config": {
+      "enable_gpu": true,
+      "segment_length": 5.0,
+      "language": "en",
+      "unified_model": "whisperx-base-with-diarization"
+    },
+    "subtitle_optimization": true
+  },
+  "speakers": {
+    "SPEAKER_03": {
+      "total_duration": 27.641,
+      "segment_count": 1
+    },
+    "SPEAKER_02": {
+      "total_duration": 72.88300000000001,
+      "segment_count": 3
+    },
+    "SPEAKER_01": {
+      "total_duration": 13.364999999999995,
+      "segment_count": 1
+    },
+    "SPEAKER_00": {
+      "total_duration": 0.9619999999999891,
+      "segment_count": 1
+    }
+  },
+  "segments": [
+    {
+      "start_time": 4.908,
+      "end_time": 32.549,
+      "duration": 27.641,
+      "speaker_id": "SPEAKER_03",
+      "acoustic_features": {
+        "volume_db": -20.532,
+        "pitch_hz": 258.654,
+        "spectral_centroid": 2106.163,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 258.654,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "You know what we should all do? Go see a musical. Sure. And you know which one we should see? The 1996 Tony Award winner. Do you happen to know the name of that one? I don't know, Greece? No. Rent?",
+      "words": [
+        {
+          "word": "You",
+          "start_time": 4.91,
+          "end_time": 5.58,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know",
+          "start_time": 5.58,
+          "end_time": 6.26,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "what",
+          "start_time": 6.26,
+          "end_time": 6.93,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we",
+          "start_time": 6.93,
+          "end_time": 7.6,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "should",
+          "start_time": 7.6,
+          "end_time": 8.28,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "all",
+          "start_time": 8.28,
+          "end_time": 8.95,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do?",
+          "start_time": 8.95,
+          "end_time": 9.63,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Go",
+          "start_time": 9.63,
+          "end_time": 10.3,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "see",
+          "start_time": 10.3,
+          "end_time": 10.98,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 10.98,
+          "end_time": 11.65,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "musical.",
+          "start_time": 11.65,
+          "end_time": 12.32,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Sure.",
+          "start_time": 12.32,
+          "end_time": 13.0,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 13.0,
+          "end_time": 13.67,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 13.67,
+          "end_time": 14.35,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know",
+          "start_time": 14.35,
+          "end_time": 15.02,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "which",
+          "start_time": 15.02,
+          "end_time": 15.69,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one",
+          "start_time": 15.69,
+          "end_time": 16.37,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we",
+          "start_time": 16.37,
+          "end_time": 17.04,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "should",
+          "start_time": 17.04,
+          "end_time": 17.72,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "see?",
+          "start_time": 17.72,
+          "end_time": 18.39,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "The",
+          "start_time": 18.39,
+          "end_time": 19.07,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "1996",
+          "start_time": 19.07,
+          "end_time": 19.74,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Tony",
+          "start_time": 19.74,
+          "end_time": 20.41,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Award",
+          "start_time": 20.41,
+          "end_time": 21.09,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "winner.",
+          "start_time": 21.09,
+          "end_time": 21.76,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Do",
+          "start_time": 21.76,
+          "end_time": 22.44,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 22.44,
+          "end_time": 23.11,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "happen",
+          "start_time": 23.11,
+          "end_time": 23.78,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 23.78,
+          "end_time": 24.46,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know",
+          "start_time": 24.46,
+          "end_time": 25.13,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 25.13,
+          "end_time": 25.81,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "name",
+          "start_time": 25.81,
+          "end_time": 26.48,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "of",
+          "start_time": 26.48,
+          "end_time": 27.16,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 27.16,
+          "end_time": 27.83,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one?",
+          "start_time": 27.83,
+          "end_time": 28.5,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 28.5,
+          "end_time": 29.18,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "don't",
+          "start_time": 29.18,
+          "end_time": 29.85,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "know,",
+          "start_time": 29.85,
+          "end_time": 30.53,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Greece?",
+          "start_time": 30.53,
+          "end_time": 31.2,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "No.",
+          "start_time": 31.2,
+          "end_time": 31.87,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Rent?",
+          "start_time": 31.87,
+          "end_time": 32.55,
+          "duration": 0.67,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 33.815,
+      "end_time": 59.87,
+      "duration": 26.055,
+      "speaker_id": "SPEAKER_02",
+      "acoustic_features": {
+        "volume_db": -20.05,
+        "pitch_hz": 218.763,
+        "spectral_centroid": 2166.501,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 218.763,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Yes, rent! Okay, so when do you want to go? What? Oh, I'm sorry, I can't. I'm busy. Hey. Man, it is so hard to shop for girls. Yes, it is, at Office, Max. Where did you get her? A pen.",
+      "words": [
+        {
+          "word": "Yes,",
+          "start_time": 33.81,
+          "end_time": 34.45,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "rent!",
+          "start_time": 34.45,
+          "end_time": 35.09,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Okay,",
+          "start_time": 35.09,
+          "end_time": 35.72,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "so",
+          "start_time": 35.72,
+          "end_time": 36.36,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "when",
+          "start_time": 36.36,
+          "end_time": 36.99,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "do",
+          "start_time": 36.99,
+          "end_time": 37.63,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 37.63,
+          "end_time": 38.26,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "want",
+          "start_time": 38.26,
+          "end_time": 38.9,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 38.9,
+          "end_time": 39.53,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "go?",
+          "start_time": 39.53,
+          "end_time": 40.17,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "What?",
+          "start_time": 40.17,
+          "end_time": 40.81,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Oh,",
+          "start_time": 40.81,
+          "end_time": 41.44,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I'm",
+          "start_time": 41.44,
+          "end_time": 42.08,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "sorry,",
+          "start_time": 42.08,
+          "end_time": 42.71,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 42.71,
+          "end_time": 43.35,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can't.",
+          "start_time": 43.35,
+          "end_time": 43.98,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I'm",
+          "start_time": 43.98,
+          "end_time": 44.62,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "busy.",
+          "start_time": 44.62,
+          "end_time": 45.25,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Hey.",
+          "start_time": 45.25,
+          "end_time": 45.89,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Man,",
+          "start_time": 45.89,
+          "end_time": 46.52,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 46.52,
+          "end_time": 47.16,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is",
+          "start_time": 47.16,
+          "end_time": 47.8,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "so",
+          "start_time": 47.8,
+          "end_time": 48.43,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "hard",
+          "start_time": 48.43,
+          "end_time": 49.07,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 49.07,
+          "end_time": 49.7,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "shop",
+          "start_time": 49.7,
+          "end_time": 50.34,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 50.34,
+          "end_time": 50.97,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "girls.",
+          "start_time": 50.97,
+          "end_time": 51.61,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Yes,",
+          "start_time": 51.61,
+          "end_time": 52.24,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 52.24,
+          "end_time": 52.88,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is,",
+          "start_time": 52.88,
+          "end_time": 53.52,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "at",
+          "start_time": 53.52,
+          "end_time": 54.15,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Office,",
+          "start_time": 54.15,
+          "end_time": 54.79,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Max.",
+          "start_time": 54.79,
+          "end_time": 55.42,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Where",
+          "start_time": 55.42,
+          "end_time": 56.06,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "did",
+          "start_time": 56.06,
+          "end_time": 56.69,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 56.69,
+          "end_time": 57.33,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "get",
+          "start_time": 57.33,
+          "end_time": 57.96,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "her?",
+          "start_time": 57.96,
+          "end_time": 58.6,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "A",
+          "start_time": 58.6,
+          "end_time": 59.23,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "pen.",
+          "start_time": 59.23,
+          "end_time": 59.87,
+          "duration": 0.64,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 61.372,
+      "end_time": 74.737,
+      "duration": 13.364999999999995,
+      "speaker_id": "SPEAKER_01",
+      "acoustic_features": {
+        "volume_db": -19.152,
+        "pitch_hz": 261.161,
+        "spectral_centroid": 1955.728,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 261.161,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "It's two gifts in one. It's a pen that's also a clock. Huh? You can't give her that. Why not? Because she's not 11. And it's not the seventh night of Hanukkah.",
+      "words": [
+        {
+          "word": "It's",
+          "start_time": 61.37,
+          "end_time": 61.79,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "two",
+          "start_time": 61.79,
+          "end_time": 62.21,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "gifts",
+          "start_time": 62.21,
+          "end_time": 62.62,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "in",
+          "start_time": 62.62,
+          "end_time": 63.04,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "one.",
+          "start_time": 63.04,
+          "end_time": 63.46,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "It's",
+          "start_time": 63.46,
+          "end_time": 63.88,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 63.88,
+          "end_time": 64.3,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "pen",
+          "start_time": 64.3,
+          "end_time": 64.71,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that's",
+          "start_time": 64.71,
+          "end_time": 65.13,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "also",
+          "start_time": 65.13,
+          "end_time": 65.55,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 65.55,
+          "end_time": 65.97,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "clock.",
+          "start_time": 65.97,
+          "end_time": 66.38,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Huh?",
+          "start_time": 66.38,
+          "end_time": 66.8,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "You",
+          "start_time": 66.8,
+          "end_time": 67.22,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can't",
+          "start_time": 67.22,
+          "end_time": 67.64,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "give",
+          "start_time": 67.64,
+          "end_time": 68.05,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "her",
+          "start_time": 68.05,
+          "end_time": 68.47,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that.",
+          "start_time": 68.47,
+          "end_time": 68.89,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Why",
+          "start_time": 68.89,
+          "end_time": 69.31,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not?",
+          "start_time": 69.31,
+          "end_time": 69.73,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Because",
+          "start_time": 69.73,
+          "end_time": 70.14,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "she's",
+          "start_time": 70.14,
+          "end_time": 70.56,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 70.56,
+          "end_time": 70.98,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "11.",
+          "start_time": 70.98,
+          "end_time": 71.4,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 71.4,
+          "end_time": 71.81,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it's",
+          "start_time": 71.81,
+          "end_time": 72.23,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 72.23,
+          "end_time": 72.65,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "the",
+          "start_time": 72.65,
+          "end_time": 73.07,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "seventh",
+          "start_time": 73.07,
+          "end_time": 73.48,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "night",
+          "start_time": 73.48,
+          "end_time": 73.9,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "of",
+          "start_time": 73.9,
+          "end_time": 74.32,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Hanukkah.",
+          "start_time": 74.32,
+          "end_time": 74.74,
+          "duration": 0.42,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 78.179,
+      "end_time": 103.019,
+      "duration": 24.840000000000003,
+      "speaker_id": "SPEAKER_02",
+      "acoustic_features": {
+        "volume_db": -20.613,
+        "pitch_hz": 258.8,
+        "spectral_centroid": 2165.225,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 258.8,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Honey, what he means by that is, while this is a very nice gift, maybe it's just not something a boyfriend gives? Sure it is. She needs a pen for work. She's writing. She turns it over. Whoa! It's time for my date with Joey! All right, look, look. What did you get for Angela Del Vecchio for her birthday? She didn't have a birthday while we were going out. For three years...",
+      "words": [
+        {
+          "word": "Honey,",
+          "start_time": 78.18,
+          "end_time": 78.52,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "what",
+          "start_time": 78.52,
+          "end_time": 78.86,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "he",
+          "start_time": 78.86,
+          "end_time": 79.2,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "means",
+          "start_time": 79.2,
+          "end_time": 79.54,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "by",
+          "start_time": 79.54,
+          "end_time": 79.88,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 79.88,
+          "end_time": 80.22,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is,",
+          "start_time": 80.22,
+          "end_time": 80.56,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "while",
+          "start_time": 80.56,
+          "end_time": 80.9,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "this",
+          "start_time": 80.9,
+          "end_time": 81.24,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is",
+          "start_time": 81.24,
+          "end_time": 81.58,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 81.58,
+          "end_time": 81.92,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "very",
+          "start_time": 81.92,
+          "end_time": 82.26,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "nice",
+          "start_time": 82.26,
+          "end_time": 82.6,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "gift,",
+          "start_time": 82.6,
+          "end_time": 82.94,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "maybe",
+          "start_time": 82.94,
+          "end_time": 83.28,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it's",
+          "start_time": 83.28,
+          "end_time": 83.62,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "just",
+          "start_time": 83.62,
+          "end_time": 83.96,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "not",
+          "start_time": 83.96,
+          "end_time": 84.3,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "something",
+          "start_time": 84.3,
+          "end_time": 84.64,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 84.64,
+          "end_time": 84.98,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "boyfriend",
+          "start_time": 84.98,
+          "end_time": 85.32,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "gives?",
+          "start_time": 85.32,
+          "end_time": 85.67,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Sure",
+          "start_time": 85.67,
+          "end_time": 86.01,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 86.01,
+          "end_time": 86.35,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "is.",
+          "start_time": 86.35,
+          "end_time": 86.69,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "She",
+          "start_time": 86.69,
+          "end_time": 87.03,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "needs",
+          "start_time": 87.03,
+          "end_time": 87.37,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 87.37,
+          "end_time": 87.71,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "pen",
+          "start_time": 87.71,
+          "end_time": 88.05,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 88.05,
+          "end_time": 88.39,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "work.",
+          "start_time": 88.39,
+          "end_time": 88.73,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "She's",
+          "start_time": 88.73,
+          "end_time": 89.07,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "writing.",
+          "start_time": 89.07,
+          "end_time": 89.41,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "She",
+          "start_time": 89.41,
+          "end_time": 89.75,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "turns",
+          "start_time": 89.75,
+          "end_time": 90.09,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it",
+          "start_time": 90.09,
+          "end_time": 90.43,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "over.",
+          "start_time": 90.43,
+          "end_time": 90.77,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Whoa!",
+          "start_time": 90.77,
+          "end_time": 91.11,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "It's",
+          "start_time": 91.11,
+          "end_time": 91.45,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "time",
+          "start_time": 91.45,
+          "end_time": 91.79,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 91.79,
+          "end_time": 92.13,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "my",
+          "start_time": 92.13,
+          "end_time": 92.47,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "date",
+          "start_time": 92.47,
+          "end_time": 92.81,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "with",
+          "start_time": 92.81,
+          "end_time": 93.15,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Joey!",
+          "start_time": 93.15,
+          "end_time": 93.49,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "All",
+          "start_time": 93.49,
+          "end_time": 93.83,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "right,",
+          "start_time": 93.83,
+          "end_time": 94.17,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "look,",
+          "start_time": 94.17,
+          "end_time": 94.51,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "look.",
+          "start_time": 94.51,
+          "end_time": 94.85,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "What",
+          "start_time": 94.85,
+          "end_time": 95.19,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "did",
+          "start_time": 95.19,
+          "end_time": 95.53,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 95.53,
+          "end_time": 95.87,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "get",
+          "start_time": 95.87,
+          "end_time": 96.21,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 96.21,
+          "end_time": 96.55,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Angela",
+          "start_time": 96.55,
+          "end_time": 96.89,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Del",
+          "start_time": 96.89,
+          "end_time": 97.23,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Vecchio",
+          "start_time": 97.23,
+          "end_time": 97.57,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 97.57,
+          "end_time": 97.91,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "her",
+          "start_time": 97.91,
+          "end_time": 98.26,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "birthday?",
+          "start_time": 98.26,
+          "end_time": 98.6,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "She",
+          "start_time": 98.6,
+          "end_time": 98.94,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "didn't",
+          "start_time": 98.94,
+          "end_time": 99.28,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "have",
+          "start_time": 99.28,
+          "end_time": 99.62,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 99.62,
+          "end_time": 99.96,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "birthday",
+          "start_time": 99.96,
+          "end_time": 100.3,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "while",
+          "start_time": 100.3,
+          "end_time": 100.64,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "we",
+          "start_time": 100.64,
+          "end_time": 100.98,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "were",
+          "start_time": 100.98,
+          "end_time": 101.32,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "going",
+          "start_time": 101.32,
+          "end_time": 101.66,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "out.",
+          "start_time": 101.66,
+          "end_time": 102.0,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "For",
+          "start_time": 102.0,
+          "end_time": 102.34,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "three",
+          "start_time": 102.34,
+          "end_time": 102.68,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "years...",
+          "start_time": 102.68,
+          "end_time": 103.02,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 106.276,
+      "end_time": 128.264,
+      "duration": 21.988000000000014,
+      "speaker_id": "SPEAKER_02",
+      "acoustic_features": {
+        "volume_db": -20.137,
+        "pitch_hz": 224.893,
+        "spectral_centroid": 1860.084,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 224.893,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "Look, it's too late and I got an audition. I can't shop anymore. I will go out and I will try to find something for her, okay? Thanks, man. And oh, while you're at it, could you get her a card? Would you like me to write her a little poem as well? Or just get a card that has a poem already in it.",
+      "words": [
+        {
+          "word": "Look,",
+          "start_time": 106.28,
+          "end_time": 106.61,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it's",
+          "start_time": 106.61,
+          "end_time": 106.95,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "too",
+          "start_time": 106.95,
+          "end_time": 107.29,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "late",
+          "start_time": 107.29,
+          "end_time": 107.63,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 107.63,
+          "end_time": 107.97,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 107.97,
+          "end_time": 108.31,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "got",
+          "start_time": 108.31,
+          "end_time": 108.64,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "an",
+          "start_time": 108.64,
+          "end_time": 108.98,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "audition.",
+          "start_time": 108.98,
+          "end_time": 109.32,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 109.32,
+          "end_time": 109.66,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "can't",
+          "start_time": 109.66,
+          "end_time": 110.0,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "shop",
+          "start_time": 110.0,
+          "end_time": 110.34,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "anymore.",
+          "start_time": 110.34,
+          "end_time": 110.67,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 110.67,
+          "end_time": 111.01,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "will",
+          "start_time": 111.01,
+          "end_time": 111.35,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "go",
+          "start_time": 111.35,
+          "end_time": 111.69,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "out",
+          "start_time": 111.69,
+          "end_time": 112.03,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "and",
+          "start_time": 112.03,
+          "end_time": 112.36,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "I",
+          "start_time": 112.36,
+          "end_time": 112.7,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "will",
+          "start_time": 112.7,
+          "end_time": 113.04,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "try",
+          "start_time": 113.04,
+          "end_time": 113.38,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 113.38,
+          "end_time": 113.72,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "find",
+          "start_time": 113.72,
+          "end_time": 114.06,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "something",
+          "start_time": 114.06,
+          "end_time": 114.39,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "for",
+          "start_time": 114.39,
+          "end_time": 114.73,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "her,",
+          "start_time": 114.73,
+          "end_time": 115.07,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "okay?",
+          "start_time": 115.07,
+          "end_time": 115.41,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Thanks,",
+          "start_time": 115.41,
+          "end_time": 115.75,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "man.",
+          "start_time": 115.75,
+          "end_time": 116.09,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "And",
+          "start_time": 116.09,
+          "end_time": 116.42,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "oh,",
+          "start_time": 116.42,
+          "end_time": 116.76,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "while",
+          "start_time": 116.76,
+          "end_time": 117.1,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you're",
+          "start_time": 117.1,
+          "end_time": 117.44,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "at",
+          "start_time": 117.44,
+          "end_time": 117.78,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it,",
+          "start_time": 117.78,
+          "end_time": 118.12,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "could",
+          "start_time": 118.12,
+          "end_time": 118.45,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 118.45,
+          "end_time": 118.79,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "get",
+          "start_time": 118.79,
+          "end_time": 119.13,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "her",
+          "start_time": 119.13,
+          "end_time": 119.47,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 119.47,
+          "end_time": 119.81,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "card?",
+          "start_time": 119.81,
+          "end_time": 120.15,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Would",
+          "start_time": 120.15,
+          "end_time": 120.48,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "you",
+          "start_time": 120.48,
+          "end_time": 120.82,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "like",
+          "start_time": 120.82,
+          "end_time": 121.16,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "me",
+          "start_time": 121.16,
+          "end_time": 121.5,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "to",
+          "start_time": 121.5,
+          "end_time": 121.84,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "write",
+          "start_time": 121.84,
+          "end_time": 122.18,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "her",
+          "start_time": 122.18,
+          "end_time": 122.51,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 122.51,
+          "end_time": 122.85,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "little",
+          "start_time": 122.85,
+          "end_time": 123.19,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "poem",
+          "start_time": 123.19,
+          "end_time": 123.53,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "as",
+          "start_time": 123.53,
+          "end_time": 123.87,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "well?",
+          "start_time": 123.87,
+          "end_time": 124.2,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "Or",
+          "start_time": 124.2,
+          "end_time": 124.54,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "just",
+          "start_time": 124.54,
+          "end_time": 124.88,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "get",
+          "start_time": 124.88,
+          "end_time": 125.22,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 125.22,
+          "end_time": 125.56,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "card",
+          "start_time": 125.56,
+          "end_time": 125.9,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "that",
+          "start_time": 125.9,
+          "end_time": 126.23,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "has",
+          "start_time": 126.23,
+          "end_time": 126.57,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "a",
+          "start_time": 126.57,
+          "end_time": 126.91,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "poem",
+          "start_time": 126.91,
+          "end_time": 127.25,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "already",
+          "start_time": 127.25,
+          "end_time": 127.59,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "in",
+          "start_time": 127.59,
+          "end_time": 127.93,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        },
+        {
+          "word": "it.",
+          "start_time": 127.93,
+          "end_time": 128.26,
+          "duration": 0.34,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    },
+    {
+      "start_time": 142.473,
+      "end_time": 143.435,
+      "duration": 0.9619999999999891,
+      "speaker_id": "SPEAKER_00",
+      "acoustic_features": {
+        "volume_db": -33.162,
+        "pitch_hz": 220.755,
+        "spectral_centroid": 1213.801,
+        "zero_crossing_rate": 0.05,
+        "pitch_mean": 220.755,
+        "pitch_std": 10.0,
+        "mfcc_mean": [
+          12.0,
+          -8.0,
+          4.0
+        ]
+      },
+      "text": "you",
+      "words": [
+        {
+          "word": "you",
+          "start_time": 142.47,
+          "end_time": 143.44,
+          "duration": 0.96,
+          "acoustic_features": {
+            "volume_db": -25.0,
+            "pitch_hz": 150.0,
+            "spectral_centroid": 1500.0
+          }
+        }
+      ]
+    }
+  ],
+  "processing_time": 322.992038,
+  "error": null,
+  "error_code": null
+}


### PR DESCRIPTION
개요

WhisperX 음성 인식 파이프라인에서 음성 세그먼트 간 공백(침묵) 구간을 별도 세그먼트가 아닌 기존 화자 세그먼트에 통합하는 방식으로 변경
음성과 침묵 구간을 연속된 타임라인으로 처리하여 전체 오디오 시간을 완전히 커버
단어 수준 타이밍이 없는 세그먼트에 대한 폴백(fallback) 처리 추가

설명
What (무엇을 수정했나요?)

침묵 구간 처리 방식 변경

기존: _fill_gaps_with_silence() - 침묵 구간을 별도 세그먼트로 생성
변경: _fill_gaps_into_speaker_segments() - 침묵 구간을 인접한 화자 세그먼트에 통합


단어 수준 타이밍 보장

모든 세그먼트가 갭 필링 전에 단어 수준 타이밍을 갖도록 보장
단어 타이밍이 없는 세그먼트에 대해 폴백 단어 타이밍 생성


새로운 헬퍼 메서드 추가

_create_silence_words(): 침묵 구간에 대한 단어 객체 생성
_sort_words_by_time(): 시간순으로 단어 정렬 및 필드명 일관성 보장



Why (왜 수정했나요?)

연속성 개선: 음성과 침묵이 분리된 세그먼트가 아닌 하나의 연속된 화자 발화로 처리되어 더 자연스러운 타임라인 생성
화자 구분 유지: 침묵 구간이 가장 가까운 화자의 세그먼트에 포함되어 화자 정보 일관성 유지
타이밍 정확도: 모든 구간(음성+침묵)이 단어 수준 타이밍을 갖게 되어 정밀한 시간 동기화 가능

How (어떻게 수정했나요?)

갭 식별 및 분류

시작 부분, 세그먼트 간, 끝 부분 갭을 각각 식별
0.5초 이상의 갭만 처리 대상으로 선정


지능적 갭 할당

시작/끝 갭: 첫 번째/마지막 세그먼트에 자동 할당
중간 갭: 갭의 중점을 기준으로 더 가까운 세그먼트에 할당


침묵 단어 통합

침묵 구간을 공백 문자(" ")로 표현하는 단어 객체 생성
음향 특성(volume_db, pitch_hz 등) 포함
기존 단어와 시간순 정렬하여 통합


텍스트 표시

세그먼트에 침묵이 추가된 경우 "[SILENCE]" 마커 추가
앞쪽 침묵: "[SILENCE] {원본 텍스트}"
뒤쪽 침묵: "{원본 텍스트} [SILENCE]"



📋 체크리스트

 기능 테스트 완료
 코드 리뷰 준비 완료
 문서 업데이트 (필요시)

🔍 리뷰 포인트

갭 할당 로직: 중간 갭을 인접 세그먼트 중 더 가까운 쪽에 할당하는 방식의 적절성
필드명 일관성: start/start_time, end/end_time 등 혼재된 필드명 처리
성능 영향: 대용량 오디오 파일에서 침묵 구간 처리 시 메모리/성능 영향
침묵 임계값: 0.5초를 갭 처리 기준으로 사용한 것의 적절성